### PR TITLE
fix: clamp current_frame to be within active tag range

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -358,6 +358,11 @@ fn next_frame(
     animation: &mut Animation,
     animation_range: &Range<usize>,
 ) -> Option<FrameTransition> {
+    // FIXME: imperfect, but when the tag is changed we need to make sure we're inside the active range.
+    //   Better might be to clamp the calculated value for `next` after it has been incremented or decremented.
+    state.current_frame = state
+        .current_frame
+        .clamp(animation_range.start, animation_range.end);
     match animation.direction {
         AnimationDirection::Forward => {
             let next = state.current_frame + 1;


### PR DESCRIPTION
Not ideal, but partially solves https://github.com/Lommix/bevy_aseprite_ultra/issues/3

By clamping the value for current_frame to the active tag's frame range, we can allow systems to directly manipulate the `tag` field on an `Animation` component without causing the animation playback to cover frames that are outside the range for the given tag.


This is a more conservative fix than I first hacked together (cf. https://github.com/Lommix/bevy_aseprite_ultra/issues/3#issuecomment-2106128700).

Still not great. At the very least it saves from leaking `AnimationState` which can now stay private.