### PR TITLE
Check for changes to AsepriteSlice

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -79,7 +79,7 @@ fn insert_aseprite_slice(
             &Handle<Aseprite>,
             Option<&UiTag>,
         ),
-        With<NotLoaded>,
+        Or<(With<NotLoaded>, Changed<AsepriteSlice>)>,
     >,
     mut sprites: Query<&mut Sprite>,
     aseprites: Res<Assets<Aseprite>>,


### PR DESCRIPTION
Allows changing the Slice after creation, ran into this issue whilst using this library for my game. If I should've been doing something else let me know.

Example code:
```rust
fn tile_update_slice(
    mut tile_query: Query<&mut AsepriteSlice>,
) {
    for mut slice in &mut tile_query {
        *slice = "different_slice".into();
    }
}
```