### PR TITLE
Increase the default Atlas size to 4096

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -382,11 +382,7 @@ fn next_frame(
                     }
                 }
             } else {
-                if next < animation_range.start {
-                    state.current_frame = animation_range.start;
-                } else {
-                    state.current_frame = next;
-                }
+                state.current_frame = next;
             }
         }
         AnimationDirection::Reverse => {

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -377,7 +377,11 @@ fn next_frame(
                     }
                 }
             } else {
-                state.current_frame = next;
+                if next < animation_range.start {
+                    state.current_frame = animation_range.start;
+                } else {
+                    state.current_frame = next;
+                }
             }
         }
         AnimationDirection::Reverse => {

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -88,7 +88,8 @@ impl AssetLoader for AsepriteLoader {
             let raw = AsepriteFile::load(&bytes)?;
 
             let mut frame_images = Vec::new();
-            let mut atlas_builder = TextureAtlasBuilder::default().max_size(UVec2::splat(4096));
+            let mut atlas_builder = TextureAtlasBuilder::default();
+            atlas_builder.max_size(UVec2::splat(4096));
 
             let mut images = Vec::new();
 

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -88,7 +88,8 @@ impl AssetLoader for AsepriteLoader {
             let raw = AsepriteFile::load(&bytes)?;
 
             let mut frame_images = Vec::new();
-            let mut atlas_builder = TextureAtlasBuilder::default();
+            let mut atlas_builder = TextureAtlasBuilder::default().max_size(UVec2::splat(4096));
+
             let mut images = Vec::new();
 
             for (index, _frame) in raw.frames().iter().enumerate() {
@@ -121,7 +122,9 @@ impl AssetLoader for AsepriteLoader {
             }
 
             // ----------------------------- atlas
-            let (mut layout, image) = atlas_builder.build().unwrap();
+            let (mut layout, image) = atlas_builder.build().map_err(|e| {
+                anyhow::anyhow!("Failed to build texture atlas: {:?}", e)
+            })?;
 
             let frame_indicies = frame_images
                 .iter()


### PR DESCRIPTION
For my project, I am using some rather large sprite sheets. The default atlas size is not large enough to load said sheets. 

This is a quick dirty fix, but has been working well for loading larger sheets. 