### PR TITLE
Resolves issue where state.current_frame does not respect tags

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -437,6 +437,9 @@ fn update_animation_state(
         .map(|t| *t.range.start()..*t.range.end())
         .unwrap_or(0..aseprite.frame_durations.len() as u16);
 
+    if !range.contains(&state.current_frame) {
+        state.current_frame = range.start;
+    }
     state.elapsed += std::time::Duration::from_secs_f32(delta_secs);
 
     let Some(frame_duration) = aseprite


### PR DESCRIPTION
Resolved an issue where state.current_frame always starts at 0 regardless of the tags range

**Before:**
https://github.com/user-attachments/assets/d45b797e-38be-44ab-a2ae-7c9c9b6c3817

![Screen Recording 2024-12-09 at 1 27 55 AM](https://github.com/user-attachments/assets/8b3b455d-9705-4bf4-abdd-c4f4acc7c514)


**After:**
https://github.com/user-attachments/assets/08c62565-707d-4315-b023-0e821a805100


![Screen Recording 2024-12-09 at 1 28 50 AM](https://github.com/user-attachments/assets/c088d26b-d98c-4f20-b9c1-b7f65e362f27)




