### PR TITLE
Resolved an issue where tags would indefinitely loop

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -437,7 +437,7 @@ fn update_animation_state(
         .map(|t| *t.range.start()..*t.range.end())
         .unwrap_or(0..aseprite.frame_durations.len() as u16);
 
-    if !range.contains(&state.current_frame) {
+    if state.current_frame < range.start {
         state.current_frame = range.start;
     }
     state.elapsed += std::time::Duration::from_secs_f32(delta_secs);

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -435,7 +435,7 @@ fn update_animation_state(
 
     let range = maybe_tag
         .map(|t| *t.range.start()..*t.range.end())
-        .unwrap_or(0..aseprite.frame_durations.len() as u16);
+        .unwrap_or(0..(aseprite.frame_durations.len() - 1) as u16);
 
     if state.current_frame < range.start {
         state.current_frame = range.start;


### PR DESCRIPTION
Apologies @Lommix , My previous pr had a flaw in it. This should be the proper fix.

Prior PR: https://github.com/Lommix/bevy_aseprite_ultra/pull/18

The issue was that the tag would never finish because the introduced code would reset it before attempting the overflow frame. I didn't do a thorough job validating the previous PR. I did this time 😅 

I'm still seeing one more issue, where animations without tags do not call "Finished" events. I'm exploring this
**Exploration Complete**: There was an issue where when a tag wasn't specified, the range was not correct. I made an adjustment to this behaviour.

Here is now our behaviour in our app with these changes (works as expected):

https://github.com/user-attachments/assets/1ca9e3e9-66c1-4f33-9fd2-756726656a06


