### PR TITLE
Relative Frames, and Animation frame jumping via Relative Frame Groups

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -23,71 +23,7 @@ fn setup(mut cmd: Commands, server: Res<AssetServer>) {
         Transform::from_translation(Vec3::new(15., 0., 0.)),
     ));
 
-    cmd.spawn((
-        AseSpriteAnimation {
-            animation: Animation::tag("walk-up"),
-            aseprite: server.load("player.aseprite"),
-        },
-        Transform::from_translation(Vec3::new(0., 0., 0.)),
-    ));
-
-    cmd.spawn((
-        AseSpriteAnimation {
-            animation: Animation::tag("walk-down"),
-            aseprite: server.load("player.aseprite"),
-        },
-        Transform::from_translation(Vec3::new(-15., 0., 0.)),
-    ));
-
-    cmd.spawn((
-        AseSpriteAnimation {
-            animation: Animation::default()
-                .with_direction(AnimationDirection::Reverse)
-                .with_repeat(AnimationRepeat::Count(1)),
-            aseprite: server.load("player.aseprite"),
-        },
-        Transform::from_translation(Vec3::new(0., -20., 0.)),
-    ));
-
-    cmd.spawn((
-        AseSpriteAnimation {
-            animation: Animation::tag("walk-right"),
-            aseprite: server.load("player.aseprite"),
-        },
-        Transform::from_translation(Vec3::new(15., -20., 0.)),
-        Sprite {
-            flip_x: true,
-            ..default()
-        },
-    ));
-
-    cmd.spawn((
-        AseSpriteAnimation {
-            animation: Animation::default().with_tag("squash"),
-            aseprite: server.load("ball.aseprite"),
-        },
-        Transform::from_translation(Vec3::new(0., 20., 0.)),
-    ));
-
-    cmd.spawn((
-        AseSpriteSlice {
-            name: "ghost_red".into(),
-            aseprite: server.load("ghost_slices.aseprite"),
-        },
-        Transform::from_translation(Vec3::new(50., 0., 0.)),
-    ));
-
-    cmd.spawn((
-        AseSpriteSlice {
-            name: "ghost_blue".into(),
-            aseprite: server.load("ghost_slices.aseprite"),
-        },
-        Sprite {
-            flip_x: true,
-            ..default()
-        },
-        Transform::from_translation(Vec3::new(80., 0., 0.)),
-    ));
+   
 }
 
 fn events(mut events: EventReader<AnimationEvents>, mut cmd: Commands) {

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -23,7 +23,71 @@ fn setup(mut cmd: Commands, server: Res<AssetServer>) {
         Transform::from_translation(Vec3::new(15., 0., 0.)),
     ));
 
-   
+    cmd.spawn((
+        AseSpriteAnimation {
+            animation: Animation::tag("walk-up"),
+            aseprite: server.load("player.aseprite"),
+        },
+        Transform::from_translation(Vec3::new(0., 0., 0.)),
+    ));
+
+    cmd.spawn((
+        AseSpriteAnimation {
+            animation: Animation::tag("walk-down"),
+            aseprite: server.load("player.aseprite"),
+        },
+        Transform::from_translation(Vec3::new(-15., 0., 0.)),
+    ));
+
+    cmd.spawn((
+        AseSpriteAnimation {
+            animation: Animation::default()
+                .with_direction(AnimationDirection::Reverse)
+                .with_repeat(AnimationRepeat::Count(1)),
+            aseprite: server.load("player.aseprite"),
+        },
+        Transform::from_translation(Vec3::new(0., -20., 0.)),
+    ));
+
+    cmd.spawn((
+        AseSpriteAnimation {
+            animation: Animation::tag("walk-right"),
+            aseprite: server.load("player.aseprite"),
+        },
+        Transform::from_translation(Vec3::new(15., -20., 0.)),
+        Sprite {
+            flip_x: true,
+            ..default()
+        },
+    ));
+
+    cmd.spawn((
+        AseSpriteAnimation {
+            animation: Animation::default().with_tag("squash"),
+            aseprite: server.load("ball.aseprite"),
+        },
+        Transform::from_translation(Vec3::new(0., 20., 0.)),
+    ));
+
+    cmd.spawn((
+        AseSpriteSlice {
+            name: "ghost_red".into(),
+            aseprite: server.load("ghost_slices.aseprite"),
+        },
+        Transform::from_translation(Vec3::new(50., 0., 0.)),
+    ));
+
+    cmd.spawn((
+        AseSpriteSlice {
+            name: "ghost_blue".into(),
+            aseprite: server.load("ghost_slices.aseprite"),
+        },
+        Sprite {
+            flip_x: true,
+            ..default()
+        },
+        Transform::from_translation(Vec3::new(80., 0., 0.)),
+    ));
 }
 
 fn events(mut events: EventReader<AnimationEvents>, mut cmd: Commands) {

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -191,7 +191,7 @@ impl Animation {
         self.queue.clear();
     }
 
-    /// instanly starts playing a new animation, clearing any item left in the queue.
+    /// instanly starts playing a new animation starting with same relative frame only if the new relative group is the same as the previous one.
     pub fn play_with_relative_group(&mut self, tag: impl Into<String>, repeat: AnimationRepeat, new_relative_group: u16) {
         self.tag = Some(tag.into());
         self.new_relative_group = new_relative_group;

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -354,10 +354,12 @@ fn update_aseprite_sprite_animation<T: AseAnimation>(
                     state.current_frame = *range.start();
                     state.relative_frame = 0;
                     state.elapsed = std::time::Duration::ZERO;
+                    
 
                 } else {
-                    state.current_frame = *range.start() + (state.relative_frame  % (*range.end() - *range.start()));
-
+                    state.relative_frame = (state.relative_frame)  % (*range.end() *range.start()-1);
+                    state.current_frame = *range.start() + state.relative_frame;
+                    
 
                 }
             }
@@ -383,6 +385,7 @@ fn update_aseprite_sprite_animation<T: AseAnimation>(
         if state.elapsed > *frame_duration {
             cmd.trigger_targets(NextFrameEvent, entity);
             state.elapsed = Duration::from_secs_f32(state.elapsed.as_secs_f32() % frame_duration.as_secs_f32());
+
         }
     }
 }


### PR DESCRIPTION
Hello!

I needed to change the animation tags while keeping the same relative frame as the last animation state.  Everything that would impact your current version of the code is behind a hold_relative_frame boolean.  When you toggle this to true, and then call the function play_with_relative_group, you can swap between any tag while keeping the relative animation frame constant as long as the relative group assigned is the same.

```rust
 SolomonAnimationState::Swipe => {
    ase_sprite_animation.animation.hold_relative_frame = true;
    match player.direction {

        PlayerDirection::North => {
            ase_sprite_animation.animation.play_with_relative_group("swipe-north", AnimationRepeat::Count(0), 1);
        }
        PlayerDirection::Northeast => {
            ase_sprite_animation.animation.play_with_relative_group("swipe-northeast", AnimationRepeat::Count(0),1);
        }
        PlayerDirection::East => {
            ase_sprite_animation.animation.play_with_relative_group("swipe-east", AnimationRepeat::Count(0),1);
        }
        PlayerDirection::Southeast => {
            ase_sprite_animation.animation.play_with_relative_group("swipe-southeast", AnimationRepeat::Count(0),1);
        }
        PlayerDirection::South => {
            ase_sprite_animation.animation.play_with_relative_group("swipe-south", AnimationRepeat::Count(0),1);
        }
        PlayerDirection::Southwest => {
            ase_sprite_animation.animation.play_with_relative_group("swipe-southwest", AnimationRepeat::Count(0),1);
        }
        PlayerDirection::West => {
            ase_sprite_animation.animation.play_with_relative_group("swipe-west", AnimationRepeat::Count(0),1);
        }
        PlayerDirection::Northwest => {
            ase_sprite_animation.animation.play_with_relative_group("swipe-northwest", AnimationRepeat::Count(0),1);
        }
    };
}
```


https://github.com/user-attachments/assets/1de26082-7bc2-4f78-b6d3-454a35f4c7c9





