### PR TITLE
Add asset processing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,8 @@ asset_processing = [
   "dep:image",
   "bevy/asset_processor",
 ]
+
+[[example]]
+name = "asset_processing"
+path = "examples/processing/asset_processing.rs"
+required-features = ["asset_processing"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,10 @@ bevy = { version = "0.15", features = [
 ] }
 
 [features]
-asset_processing = ["bevy/serialize", "bevy/qoi", "dep:rmp-serde", "dep:image"]
+asset_processing = [
+  "bevy/serialize",
+  "bevy/qoi",
+  "dep:rmp-serde",
+  "dep:image",
+  "bevy/asset_processor",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ aseprite-loader = "0.3.3"
 uuid = "1.9.1"
 thiserror = "2.0.0"
 serde = "1.0.218"
+rmp-serde = { version = "1.3.0", optional = true }
+image = { version = "0.25.6", optional = true }
 
 
 [dev-dependencies]
@@ -28,3 +30,6 @@ bevy = { version = "0.15", features = [
   "multi_threaded",
   "bevy_window",
 ] }
+
+[features]
+asset_processing = ["bevy/serialize", "bevy/qoi", "dep:rmp-serde", "dep:image"]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ hot reloading. You can also import static sprites from an aseprite atlas type fi
 cargo run --example slices
 cargo run --example animations
 cargo run --example ui
+cargo run --example asset_processing --features asset_processing
 ```
 
 ![Example](docs/example.gif)

--- a/README.md
+++ b/README.md
@@ -136,11 +136,11 @@ Simply enable asset processing in your `AssetPlugin` like so:
 
 ```rust
 App::new()
-  .add_plugins(DefaultPlugins.set(AssetPlugin {
-    mode: AssetMode::Processed,
-    ..Default::default(),
-  }))
-  .run();
+    .add_plugins(DefaultPlugins.set(AssetPlugin {
+        mode: AssetMode::Processed,
+        ..Default::default(),
+    }))
+    .run();
 ```
 
 Then run with the feature `asset_processing` enabled, e.g.:

--- a/README.md
+++ b/README.md
@@ -14,26 +14,22 @@ hot reloading. You can also import static sprites from an aseprite atlas type fi
 
 ## Supported aseprite features
 
--   Animations
--   Tags
--   Frame duration, repeat, and animation direction
--   Layer visibility
--   Blend modes
--   Static slices and pivot offsets
+- Animations
+- Tags
+- Frame duration, repeat, and animation direction
+- Layer visibility
+- Blend modes
+- Static slices and pivot offsets
 
 ## Features in bevy
 
--   Hot reload anything, anytime, anywhere!
--   Full control over animations using Components.
--   One shot animations and events when they finish.
--   Static sprites with slices. Use aseprite for all your icon and UI needs!
+- Hot reload anything, anytime, anywhere!
+- Full control over animations using Components.
+- One shot animations and events when they finish.
+- Static sprites with slices. Use aseprite for all your icon and UI needs!
+- Asset processor which converts the aseprite file to a custom format.
 
 (hot reloading requires the `file_watcher` feature in bevy)
-
-## Embedding Assets
-
-There is currently no asset preprocessor. If you do not want to ship raw aseprite files, use [`bevy_embedded_assets`](https://github.com/vleue/bevy_embedded_assets)
-to embed your assets into the final binary.
 
 ## Example
 
@@ -133,3 +129,24 @@ cmd.spawn((
         },
 ));
 ```
+
+## Enable Asset Processing
+
+Simply enable asset processing in your `AssetPlugin` like so:
+
+```rust
+App::new()
+  .add_plugins(DefaultPlugins.set(AssetPlugin {
+    mode: AssetMode::Processed,
+    ..Default::default(),
+  }))
+  .run();
+```
+
+Then run with the feature `asset_processing` enabled, e.g.:
+
+```
+cargo run --features asset_processing
+```
+
+Then load your aseprite files in code as usual!

--- a/examples/processing/asset_processing.rs
+++ b/examples/processing/asset_processing.rs
@@ -1,0 +1,112 @@
+//! This example is identical to the `animation` example, except it uses asset processing.
+
+use bevy::{image::ImageSamplerDescriptor, prelude::*};
+use bevy_aseprite_ultra::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins(
+            DefaultPlugins
+                .set(ImagePlugin {
+                    default_sampler: ImageSamplerDescriptor::nearest(),
+                })
+                .set(AssetPlugin {
+                    mode: AssetMode::Processed,
+                    // You don't need to do this in your own project, here we are changing the
+                    // processed path so that it ends up in the same directory as this file.
+                    processed_file_path: "examples/processing/imported_assets/Default".into(),
+                    ..Default::default()
+                }),
+        )
+        .add_plugins(AsepriteUltraPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, events)
+        .run();
+}
+
+fn setup(mut cmd: Commands, server: Res<AssetServer>) {
+    cmd.spawn((Camera2d, Transform::default().with_scale(Vec3::splat(0.15))));
+
+    cmd.spawn((
+        AseSpriteAnimation {
+            animation: Animation::tag("walk-right"),
+            aseprite: server.load("player.aseprite"),
+        },
+        Transform::from_translation(Vec3::new(15., 0., 0.)),
+    ));
+
+    cmd.spawn((
+        AseSpriteAnimation {
+            animation: Animation::tag("walk-up"),
+            aseprite: server.load("player.aseprite"),
+        },
+        Transform::from_translation(Vec3::new(0., 0., 0.)),
+    ));
+
+    cmd.spawn((
+        AseSpriteAnimation {
+            animation: Animation::tag("walk-down"),
+            aseprite: server.load("player.aseprite"),
+        },
+        Transform::from_translation(Vec3::new(-15., 0., 0.)),
+    ));
+
+    cmd.spawn((
+        AseSpriteAnimation {
+            animation: Animation::default()
+                .with_direction(AnimationDirection::Reverse)
+                .with_repeat(AnimationRepeat::Count(1)),
+            aseprite: server.load("player.aseprite"),
+        },
+        Transform::from_translation(Vec3::new(0., -20., 0.)),
+    ));
+
+    cmd.spawn((
+        AseSpriteAnimation {
+            animation: Animation::tag("walk-right"),
+            aseprite: server.load("player.aseprite"),
+        },
+        Transform::from_translation(Vec3::new(15., -20., 0.)),
+        Sprite {
+            flip_x: true,
+            ..default()
+        },
+    ));
+
+    cmd.spawn((
+        AseSpriteAnimation {
+            animation: Animation::default().with_tag("squash"),
+            aseprite: server.load("ball.aseprite"),
+        },
+        Transform::from_translation(Vec3::new(0., 20., 0.)),
+    ));
+
+    cmd.spawn((
+        AseSpriteSlice {
+            name: "ghost_red".into(),
+            aseprite: server.load("ghost_slices.aseprite"),
+        },
+        Transform::from_translation(Vec3::new(50., 0., 0.)),
+    ));
+
+    cmd.spawn((
+        AseSpriteSlice {
+            name: "ghost_blue".into(),
+            aseprite: server.load("ghost_slices.aseprite"),
+        },
+        Sprite {
+            flip_x: true,
+            ..default()
+        },
+        Transform::from_translation(Vec3::new(80., 0., 0.)),
+    ));
+}
+
+fn events(mut events: EventReader<AnimationEvents>, mut cmd: Commands) {
+    for event in events.read() {
+        match event {
+            AnimationEvents::Finished(entity) => cmd.entity(*entity).despawn_recursive(),
+            AnimationEvents::LoopCycleFinished(_entity) => (),
+        };
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,21 @@ pub enum AsepriteError {
     LoadingError(#[from] LoadSpriteError),
     #[error("failed to combine aseprite layers")]
     LoadingImageError(#[from] LoadImageError),
-    #[error("failed to read byte stream to end")]
+    #[error("failed to read byte stream")]
     ReadError,
+    #[cfg(feature = "asset_processing")]
+    #[error("failed to write to processed asset")]
+    WriteError,
+    #[cfg(feature = "asset_processing")]
+    #[error("failed to serialize aseprite data")]
+    SerializeError(#[from] rmp_serde::encode::Error),
+    #[cfg(feature = "asset_processing")]
+    #[error("failed to deserialize processed aseprite data {0}")]
+    DeserializeError(#[from] rmp_serde::decode::Error),
+    #[cfg(feature = "asset_processing")]
+    #[error("failed to write image data")]
+    ImageError(#[from] image::ImageError),
+    #[cfg(feature = "asset_processing")]
+    #[error("failed to read image data")]
+    BevyTextureError(#[from] bevy::image::TextureError),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,13 +7,14 @@ use bevy::prelude::*;
 pub(crate) mod animation;
 pub(crate) mod error;
 pub(crate) mod loader;
+#[cfg(feature = "asset_processing")]
+pub(crate) mod processor;
 pub(crate) mod slice;
 
 pub mod prelude {
     pub use crate::animation::{
         Animation, AnimationDirection, AnimationEvents, AnimationRepeat, AnimationState,
-        AseSpriteAnimation, AseUiAnimation,  ManualTick, NextFrameEvent,
-        PlayDirection,
+        AseSpriteAnimation, AseUiAnimation, ManualTick, NextFrameEvent, PlayDirection,
     };
     pub use crate::loader::{Aseprite, AsepriteLoaderSettings};
     pub use crate::slice::{AseSpriteSlice, AseUiSlice};
@@ -70,6 +71,8 @@ impl Plugin for AsepriteUltraPlugin {
         app.add_plugins(loader::AsepriteLoaderPlugin);
         app.add_plugins(slice::AsepriteSlicePlugin);
         app.add_plugins(animation::AsepriteAnimationPlugin);
+        #[cfg(feature = "asset_processing")]
+        app.add_plugins(processor::AsepriteProcessorPlugin);
     }
 }
 

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -26,13 +26,16 @@ impl Plugin for AsepriteLoaderPlugin {
 //represantion and can make use of the asset prepocessor. No longer need
 //to ship or bundle aseprite binaries into your release.
 #[derive(Asset, Default, TypePath, Debug)]
+#[cfg_attr(feature = "asset_processing", derive(Serialize, Deserialize))]
 pub struct Aseprite {
     pub slices: HashMap<String, SliceMeta>,
     pub tags: HashMap<String, TagMeta>,
     pub frame_durations: Vec<std::time::Duration>,
+    #[cfg_attr(feature = "asset_processing", serde(skip))]
     pub atlas_layout: Handle<TextureAtlasLayout>,
+    #[cfg_attr(feature = "asset_processing", serde(skip))]
     pub atlas_image: Handle<Image>,
-    frame_indicies: Vec<usize>,
+    pub(crate) frame_indicies: Vec<usize>,
 }
 
 impl Aseprite {
@@ -45,13 +48,27 @@ impl Aseprite {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "asset_processing", derive(Serialize, Deserialize))]
 pub struct TagMeta {
+    #[cfg_attr(feature = "asset_processing", serde(with = "AnimationDirectionDef"))]
     pub direction: AnimationDirection,
     pub range: std::ops::RangeInclusive<u16>,
     pub repeat: u16,
 }
 
+#[cfg(feature = "asset_processing")]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "AnimationDirection")]
+enum AnimationDirectionDef {
+    Forward,
+    Reverse,
+    PingPong,
+    PingPongReverse,
+    Unknown(u8),
+}
+
 #[derive(Debug)]
+#[cfg_attr(feature = "asset_processing", derive(Serialize, Deserialize))]
 pub struct SliceMeta {
     pub rect: Rect,
     pub atlas_id: usize,

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,0 +1,179 @@
+use std::io::Cursor;
+
+use bevy::{
+    asset::{
+        processor::LoadTransformAndSave,
+        saver::{AssetSaver, SavedAsset},
+        transformer::IdentityAssetTransformer,
+        AssetLoader, AsyncWriteExt,
+    },
+    image::{CompressedImageFormats, ImageFormatSetting, ImageLoaderSettings, ImageType},
+    prelude::*,
+    render::renderer::RenderDevice,
+};
+use image::ImageFormat;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    error::AsepriteError,
+    loader::{Aseprite, AsepriteLoader},
+};
+
+pub struct AsepriteProcessorPlugin;
+
+impl Plugin for AsepriteProcessorPlugin {
+    fn build(&self, app: &mut App) {
+        app.register_asset_processor::<LoadTransformAndSave<AsepriteLoader, IdentityAssetTransformer<Aseprite>, AsepriteSaver>>(LoadTransformAndSave::new(IdentityAssetTransformer::new(), AsepriteSaver));
+        app.set_default_asset_processor::<LoadTransformAndSave<AsepriteLoader, IdentityAssetTransformer<Aseprite>, AsepriteSaver>>("aseprite");
+        app.set_default_asset_processor::<LoadTransformAndSave<AsepriteLoader, IdentityAssetTransformer<Aseprite>, AsepriteSaver>>("ase");
+    }
+
+    fn finish(&self, app: &mut App) {
+        let supported_compressed_formats = match app.world().get_resource::<RenderDevice>() {
+            Some(render_device) => CompressedImageFormats::from_features(render_device.features()),
+
+            None => CompressedImageFormats::NONE,
+        };
+
+        app.register_asset_loader(ProcessedAsepriteLoader {
+            supported_compressed_formats,
+        });
+    }
+}
+
+#[derive(Serialize)]
+struct AsepriteSerialize<'a> {
+    #[serde(flatten)]
+    pub aseprite: &'a Aseprite,
+    pub atlas_layout: &'a TextureAtlasLayout,
+}
+
+#[derive(Deserialize)]
+struct AsepriteDeserialize {
+    #[serde(flatten)]
+    pub aseprite: Aseprite,
+    pub atlas_layout: TextureAtlasLayout,
+}
+
+struct AsepriteSaver;
+
+impl AssetSaver for AsepriteSaver {
+    type Asset = Aseprite;
+
+    type Settings = ();
+
+    type OutputLoader = ProcessedAsepriteLoader;
+
+    type Error = super::error::AsepriteError;
+
+    async fn save(
+        &self,
+        writer: &mut bevy::asset::io::Writer,
+        asset: bevy::asset::saver::SavedAsset<'_, Self::Asset>,
+        _settings: &Self::Settings,
+    ) -> Result<<Self::OutputLoader as bevy::asset::AssetLoader>::Settings, Self::Error> {
+        let texture_atlas_layout: SavedAsset<TextureAtlasLayout> = asset
+            .get_labeled("atlas_layout")
+            .expect("atlas_layout should exist");
+        let atlas_texture: SavedAsset<Image> = asset
+            .get_labeled("atlas_texture")
+            .expect("atlas_texture should exist");
+
+        let aseprite_ser = AsepriteSerialize {
+            aseprite: asset.get(),
+            atlas_layout: texture_atlas_layout.get(),
+        };
+
+        let msgpack_buf = rmp_serde::to_vec(&aseprite_ser)?;
+
+        // Write length of msgpack segment
+        writer
+            .write_all(&((msgpack_buf.len() as u64).to_be_bytes()))
+            .await
+            .map_err(|_| AsepriteError::WriteError)?;
+
+        // Write msgpack itself
+        writer
+            .write_all(&msgpack_buf)
+            .await
+            .map_err(|_| AsepriteError::WriteError)?;
+
+        let mut image_buf = Vec::new();
+        let mut image_write = Cursor::new(&mut image_buf);
+
+        let dynamic = atlas_texture
+            .clone()
+            .try_into_dynamic()
+            .expect("Atlas image should be of a supported image type");
+        dynamic.write_to(&mut image_write, ImageFormat::Qoi)?;
+
+        writer
+            .write_all(&image_buf)
+            .await
+            .map_err(|_| AsepriteError::WriteError)?;
+
+        Ok(ImageLoaderSettings {
+            format: ImageFormatSetting::Format(bevy::prelude::ImageFormat::Qoi),
+            is_srgb: atlas_texture.texture_descriptor.format.is_srgb(),
+            sampler: atlas_texture.sampler.clone(),
+            asset_usage: atlas_texture.asset_usage,
+        })
+    }
+}
+
+struct ProcessedAsepriteLoader {
+    supported_compressed_formats: CompressedImageFormats,
+}
+
+impl AssetLoader for ProcessedAsepriteLoader {
+    type Asset = Aseprite;
+
+    type Settings = ImageLoaderSettings;
+
+    type Error = AsepriteError;
+
+    async fn load(
+        &self,
+        reader: &mut dyn bevy::asset::io::Reader,
+        settings: &Self::Settings,
+        load_context: &mut bevy::asset::LoadContext<'_>,
+    ) -> Result<Self::Asset, Self::Error> {
+        let mut buf = Vec::new();
+        reader
+            .read_to_end(&mut buf)
+            .await
+            .map_err(|_| AsepriteError::ReadError)?;
+
+        let msgpack_size = u64::from_be_bytes(
+            (&buf[..8])
+                .try_into()
+                .expect("Buffer should be at least 8 bytes long"),
+        );
+
+        let msgpack = &buf[8..8 + msgpack_size as usize];
+
+        let de: AsepriteDeserialize = rmp_serde::from_slice(msgpack)?;
+
+        let atlas_texture_buf = &buf[8 + msgpack_size as usize..];
+
+        let atlas_texture = Image::from_buffer(
+            atlas_texture_buf,
+            ImageType::Format(bevy::prelude::ImageFormat::Qoi),
+            self.supported_compressed_formats,
+            settings.is_srgb,
+            settings.sampler.clone(),
+            settings.asset_usage,
+        )?;
+
+        let atlas_layout_handle =
+            load_context.add_labeled_asset("atlas_layout".into(), de.atlas_layout);
+        let atlas_texture_handle =
+            load_context.add_labeled_asset("atlas_texture".into(), atlas_texture);
+
+        Ok(Aseprite {
+            atlas_layout: atlas_layout_handle,
+            atlas_image: atlas_texture_handle,
+            ..de.aseprite
+        })
+    }
+}


### PR DESCRIPTION
This fixes #7.

# Overview of Changes
- Added a cargo feature `asset_processing`. If this feature is not enabled, this crate would be identical to before this change. Only when this is enabled is the asset processing structs etc available to use.
- Added a `LoadTransformAndSave` processor which uses the original `AsepriteLoader` to load the aseprite files into the `Aseprite` asset, and a new `AsepriteSaver` which outputs a file with a custom format (see below) which would be loaded by a new `ProcessedAsepriteLoader`.

# Workflow Changes
Nothin changes here, all the user needs to do to switch between using asset processing and not using it is by enabling the feature and also setting the `mode` in the `AssetPlugin` to `Processed`.

# Processed Asset Format
These files would contain the following:

- The first 8 bytes: The size of the Message Pack section in bytes, encoded in the big-endian byte-order.
- The Message Pack section: This contains everything stored in the `Aseprite` asset *except* the `Image`. We serialize the data using `serde` into the Message Pack format, which is very compact.
- The image data. Currently this is encoded with the QOI image format, which is very fast to decode into raw pixel data, while being comparable to the amount of lossless compression possible in PNG files. I did initially try to use the Basis Universal format which Bevy uses as the processed form of textures, but it yielded some extremely large files, which was not ideal.

# Caveats
For some of the assets (namely `ball.aseprite` and `ghost_slices.aseprite` in the examples) the processor produced slightly larger outputs. This seems to be because aseprite does not store completely transparent pixels. I don't think this is particularly a big problem because this only happens when an asset has a large proportion of transparent pixels to non-transparent pixels. However if needed we may be able to include an option which allows the user to turn on further compression of the processed assets. 