### PR TITLE
Optimize slice rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## WIP
+
+- Optimized slice rendering.
+
 ## 0.6.1
 
 - feature gated 3d rendering to a "3d" feature flag.

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -108,17 +108,22 @@ pub struct AseSlice {
 }
 
 pub fn render_slice<T: RenderSlice + Component<Mutability = Mutable>>(
-    mut nodes: Query<(&mut T, &AseSlice)>,
+    mut slices: Query<(&mut T, Ref<AseSlice>)>,
     aseprites: Res<Assets<Aseprite>>,
     mut extra: <T as RenderSlice>::Extra<'_>,
 ) {
-    for (mut target, slice) in &mut nodes {
+    let asset_change = aseprites.is_changed();
+
+    for (mut target, slice) in &mut slices {
+        if !asset_change && !slice.is_changed() {
+            continue;
+        }
         let Some(aseprite) = aseprites.get(&slice.aseprite) else {
-            return;
+            continue;
         };
         let Some(slice_meta) = aseprite.slices.get(&slice.name) else {
-            warn!("slice does not exists {}", slice.name);
-            return;
+            warn!("slice does not exist {}", slice.name);
+            continue;
         };
         target.render_slice(aseprite, slice_meta, &mut extra);
     }


### PR DESCRIPTION
Avoids two hashmap lookups and rendering logic when there are no changes.

This makes the code slightly more fragile because users could cause bugs by reinserting the rendering component (e.g. Sprite) instead of mutating it.