### PR TITLE
Small fixes

### DIFF
--- a/assets/my_shader.wgsl
+++ b/assets/my_shader.wgsl
@@ -10,12 +10,6 @@
 fn fragment(
     v: VertexOutput,
 ) -> @location(0) vec4<f32> {
-    var normal = normalize(v.normal);
-
-    if (!front_facing) {
-        normal = -normal;
-    }
-
     let size = textureDimensions(t);
     let uv_min = vec2f(texture_min) / vec2f(size);
     let uv_max = vec2f(texture_max) / vec2f(size);

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -8,7 +8,7 @@ impl Plugin for AsepriteAnimationPlugin {
     fn build(&self, app: &mut App) {
         app.add_event::<AnimationEvents>();
         app.add_event::<NextFrameEvent>();
-        app.add_systems(Update, update_aseprite_animation);
+        app.add_systems(PreUpdate, update_aseprite_animation);
 
         app.add_systems(Update, render_animation::<ImageNode>);
         app.add_systems(Update, render_animation::<Sprite>);


### PR DESCRIPTION
The shader example was broken because the `my_shader.wgsl` and `my_shader3d.wgsl` were swapped.
I got rid of the normals section in `my_shader3d.wgsl` because it was causing an invalid access and wasn't needed.
Made `update_aseprite_animation` run in `PreUpdate` to fix a small 1-frame delay issue.
Fixes #38