### PR TITLE
Move render systems to PostUpdate

### DIFF
--- a/examples/3d.rs
+++ b/examples/3d.rs
@@ -1,9 +1,7 @@
 use std::time::Duration;
 
 use bevy::{
-    image::ImageSamplerDescriptor,
-    prelude::*,
-    render::render_resource::AsBindGroup,
+    image::ImageSamplerDescriptor, prelude::*, render::render_resource::AsBindGroup,
     time::common_conditions::on_timer,
 };
 use bevy_aseprite_ultra::prelude::*;

--- a/examples/queue.rs
+++ b/examples/queue.rs
@@ -12,10 +12,7 @@ fn main() {
         .run();
 }
 
-fn setup<'a>(
-    mut cmd: Commands,
-    server: Res<AssetServer>,
-) {
+fn setup<'a>(mut cmd: Commands, server: Res<AssetServer>) {
     cmd.spawn((Camera2d, Transform::default().with_scale(Vec3::splat(0.15))));
 
     cmd.spawn((

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -1,6 +1,6 @@
 use crate::loader::Aseprite;
 use aseprite_loader::binary::chunks::tags::AnimationDirection as RawDirection;
-use bevy::{ecs::component::Mutable, prelude::*, sprite::Material2d};
+use bevy::{ecs::component::Mutable, prelude::*, sprite::Material2d, ui::UiSystem};
 use std::{collections::VecDeque, time::Duration};
 
 pub struct AsepriteAnimationPlugin;
@@ -10,8 +10,11 @@ impl Plugin for AsepriteAnimationPlugin {
         app.add_event::<NextFrameEvent>();
         app.add_systems(PreUpdate, update_aseprite_animation);
 
-        app.add_systems(Update, render_animation::<ImageNode>);
-        app.add_systems(Update, render_animation::<Sprite>);
+        app.add_systems(
+            PostUpdate,
+            render_animation::<ImageNode>.before(UiSystem::Prepare),
+        );
+        app.add_systems(PostUpdate, render_animation::<Sprite>);
 
         app.add_observer(next_frame);
 
@@ -93,7 +96,6 @@ impl<M: Material2d + RenderAnimation> RenderAnimation for MeshMaterial2d<M> {
         material.render_animation(aseprite, state, &mut extra.1);
     }
 }
-
 
 impl<M: UiMaterial + RenderAnimation> RenderAnimation for MaterialNode<M> {
     type Extra<'e> = (ResMut<'e, Assets<M>>, <M as RenderAnimation>::Extra<'e>);

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,10 +1,15 @@
 use crate::error::AsepriteError;
 use aseprite_loader::{binary::chunks::tags::AnimationDirection, loader::AsepriteFile};
 use bevy::{
-    asset::{io::Reader, AssetLoader}, image::ImageSampler, platform::collections::HashMap, prelude::*, render::{
+    asset::{io::Reader, AssetLoader},
+    image::ImageSampler,
+    platform::collections::HashMap,
+    prelude::*,
+    render::{
         render_asset::RenderAssetUsages,
         render_resource::{Extent3d, TextureDimension, TextureFormat},
-    }, sprite::Anchor
+    },
+    sprite::Anchor,
 };
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -3,14 +3,18 @@ use bevy::{
     ecs::component::Mutable,
     prelude::*,
     sprite::{Anchor, Material2d},
+    ui::UiSystem,
 };
 
 pub struct AsepriteSlicePlugin;
 
 impl Plugin for AsepriteSlicePlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, render_slice::<ImageNode>);
-        app.add_systems(Update, render_slice::<Sprite>);
+        app.add_systems(
+            PostUpdate,
+            render_slice::<ImageNode>.before(UiSystem::Prepare),
+        );
+        app.add_systems(PostUpdate, render_slice::<Sprite>);
         app.register_type::<AseSlice>();
     }
 }


### PR DESCRIPTION
`Update` is the schedule where most slices and animations will be spawned, so 'rendering' them should go in `PostUpdate`.