### PR TITLE
Added error handling in update_aseprite_animation to use new bevy error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ thiserror = "2.0.0"
 serde = "1.0.218"
 rmp-serde = { version = "1.3.0", optional = true }
 image = { version = "0.25.6", optional = true }
+anyhow = "1.0.98"
 
 
 [dev-dependencies]


### PR DESCRIPTION
In bevy 0.16, the ability to throw errors from plugins with the new BevyError type was added. This is a wrapper around an anyhow error that allows for adding a context string to errors and lets users of the library handle logging errors when they happen for easier recovery and debugging.

In the game I am currently developing, it is very important that libraries I use do not crash, so this would go a long way in making sure that the game does not crash at runtime if an animation with the wrong name is provided.

If there is a worry about anyhow being an additional dependency, note that in bevy 0.16 you must have anyhow installed regardless as a part of the dependency graph since it uses it under the hood, so the addition of anyhow here for getting the context function is not really increasing the overall dependencies in any project using it.

Thanks for the great work!