### PR TITLE
feat: update to bevy 0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## WIP
 
-- Optimized slice rendering.
+- optimized slice rendering.
+- updated to bevy 0.18;
 
 ## 0.6.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-bevy = { version = "0.17", default-features = false, features = [
+bevy = { version = "0.18", default-features = false, features = [
   "bevy_sprite",
   "bevy_sprite_render",
   "bevy_ui",
@@ -28,9 +28,8 @@ rmp-serde = { version = "1.3.0", optional = true }
 image = { version = "0.25.6", optional = true }
 anyhow = "1.0.98"
 
-
 [dev-dependencies]
-bevy = { version = "0.17", features = [
+bevy = { version = "0.18", features = [
   "file_watcher",
   "multi_threaded",
   "bevy_window",

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -36,10 +36,10 @@ fn setup(mut cmd: Commands, server: Res<AssetServer>) {
                 height: Val::Px(200.),
                 padding: UiRect::all(Val::Px(10.)),
                 border: UiRect::all(Val::Px(5.)),
+                border_radius: BorderRadius::all(Val::Px(15.)),
                 ..default()
             },
-            BorderColor::all(css::BLUE),
-            BorderRadius::all(Val::Px(15.)),
+            BorderColor::all(css::BLUE)
         ))
         .id();
 

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -96,7 +96,7 @@ impl From<&SliceMeta> for Anchor {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, TypePath)]
 pub struct AsepriteLoader;
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
The only changes that affected the library was that [the `AssetLoader` trait now requires `TypePath`](https://bevy.org/learn/migration-guides/0-17-to-0-18/#traits-assetloader-assettransformer-assetsaver-and-process-all-now-require-typepath). I fixed the ui example, because [`BorderRadius` is now a part of `Node`](https://bevy.org/learn/migration-guides/0-17-to-0-18/#traits-assetloader-assettransformer-assetsaver-and-process-all-now-require-typepath), and is no longer its own component.